### PR TITLE
Fix for token always being generated on instantiation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
 from os import path
-
 from setuptools import setup
-from sphinx.setup_command import BuildDoc
 
-cmdclass = {'build_sphinx': BuildDoc}
+cmdclass = {}
+
+try:
+    from sphinx.setup_command import BuildDoc
+    cmdclass['build_sphinx'] = BuildDoc
+except ImportError:
+    print('WARNING: sphinx not available, not building docs')
 
 # https://pypi.org/classifiers/
 

--- a/zoho_crm_connector/zoho_crm_api.py
+++ b/zoho_crm_connector/zoho_crm_api.py
@@ -320,7 +320,6 @@ class Zoho_crm:
                 url = self.base_url + f"users?type='AllUsers'"
                 headers = {'Authorization': 'Zoho-oauthtoken ' + data_loaded['access_token']}
                 r = self.requests_session.get(url=url, headers=headers)
-                r = self.requests_session.post(url=url)
                 if r.status_code == 401:
                     data_loaded = self._refresh_access_token()
 

--- a/zoho_crm_connector/zoho_crm_api.py
+++ b/zoho_crm_connector/zoho_crm_api.py
@@ -333,10 +333,13 @@ class Zoho_crm:
         """ This forces a new token so it should only be called
         after we know we need a new token.
         Use load_access_token to get a token, it will call this if it needs to."""
-        url=(f"https://accounts.zoho.com/oauth/v2/token?refresh_token="
-             f"{self.refresh_token}&client_id={self.client_id}&"
-             f"client_secret={self.client_secret}&grant_type=refresh_token")
-        r = requests.post(url=url)
+        payload = {
+            'client_id': self.client_id,
+            'client_secret': self.client_secret,
+            'refresh_token': self.refresh_token,
+            'grant_type': 'refresh_token'
+        }
+        r = requests.post('https://accounts.zoho.com/oauth/v2/token', data=payload)
         if r.status_code == 200:
             new_token = r.json()
             logger.info(f"New token: {new_token}")


### PR DESCRIPTION
With the current version access tokens are being created upon instantiation of the zoho_crm class, even when a valid access_token exists. This fixes that. 

Side note: Thanks for publishing this! Like yourself I'm also sick of the default sdks by Zoho.